### PR TITLE
Remove flyimg.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,6 @@ Applications designed to help or simplify building **new** images
 - [DockerSlim](https://github.com/docker-slim/docker-slim) shrinks fat Docker images creating the smallest possible images.
 - [Dockly](https://github.com/swipely/dockly) - Dockly is a gem made to ease the pain of packaging an application in Docker by [@swipely](https://github.com/swipely/)
 - [dockramp](https://github.com/jlhawn/dockramp) :skull: - Proof of Concept: A Client Driven Docker Image Builder by [@jlhawn](https://github.com/jlhawn)
-- [flyimg](http://flyimg.io/) - Docker image resizing, cropping, and compression on the fly.
 - [img](https://github.com/genuinetools/img) - Standalone, daemon-less, unprivileged Dockerfile and OCI compatible container image builder by [@genuinetools][genuinetools]
 - [kaniko](https://github.com/GoogleContainerTools/kaniko) - Build Container Images In Kubernetes. By [@GoogleContainerTools][GoogleContainerTools]
 - [makisu](https://github.com/uber/makisu) - Uber's fast and flexible unprivileged image builder for Mesos and Kubernetes, with distributed cache support. By [@uber](https://github.com/uber)


### PR DESCRIPTION
Flyimg is a PHP library for resizing image on the fly.

**[Insert the URL to be listed]**

N/A : This is for removal

**[Explain what the project is about and why it should be listed]**

This project is about a php application that can resize or crop real image (png / jpeg / ...) on the fly.

This is probably a really interesting application but, IMHO this don't belong to this list because it's not related to docker or docker image.